### PR TITLE
Scenario screen crashes and bug fixes

### DIFF
--- a/src/react-modules/character-screen/CharacterScreen.js
+++ b/src/react-modules/character-screen/CharacterScreen.js
@@ -65,7 +65,7 @@ function CharacterScreen({
                 </div>
               </div>
 
-              {/* <div className="mt-8">
+              <div className="mt-8">
                 <div className="flex justify-between mb-4">
                   <h3 className="text-xl font-bold">Your Character:</h3>
                 </div>
@@ -77,7 +77,7 @@ function CharacterScreen({
                   selectedCharacter={selectedCharacter}
                   setSelectedCharacter={setSelectedCharacter}
                 />
-              </div> */}
+              </div>
             </div>
             {/* end of column 1  */}
 

--- a/src/react-modules/credentials/CredentialsScreen.js
+++ b/src/react-modules/credentials/CredentialsScreen.js
@@ -28,6 +28,8 @@ function CredentialsScreen({
 
   // Remove a credential
   function handleCredentialRemoval(credential) {
+
+
     if (
       Object.keys(showcaseJSON.personas[selectedCharacter].credentials)
         .length === 1
@@ -43,6 +45,53 @@ function CredentialsScreen({
     setTempData((json) => {
       delete json[credential];
     });
+
+    // Find all instances of this credential being used in a scenario and remove them.
+    for (let scenarioID = 0; scenarioID < showcaseJSON.personas[selectedCharacter].scenarios.length; scenarioID++){
+      for(let stepID = 0; stepID < showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps.length; stepID++){
+
+        // If a step in a scenario has request options...
+        if(showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions){
+
+
+          // Handling attributes
+          for (let attributeList in showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest.attributes){
+            
+              let restriction = showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest.attributes[attributeList].restrictions[0]
+               if(restriction === credential){
+                setShowcaseJSON(json =>{
+                  json.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest = {
+                    "attributes": {
+                    },
+                    "predicates": {
+                    },
+                  }
+                });
+               }
+                
+            
+          }
+
+          // Handling predicates
+          for (let predicateList in showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest.predicates){
+            
+            let restriction = showcaseJSON.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest.predicates[predicateList].restrictions[0]
+             if(restriction === credential){
+              setShowcaseJSON(json =>{
+                json.personas[selectedCharacter].scenarios[scenarioID].steps[stepID].requestOptions.proofRequest = {
+                  "attributes": {
+                  },
+                  "predicates": {
+                  },
+                }
+              });
+             }
+              
+          
+        }
+        }
+      }
+    }
   }
 
   // Handle all inputs

--- a/src/react-modules/pages/ScenarioPage.jsx
+++ b/src/react-modules/pages/ScenarioPage.jsx
@@ -65,19 +65,12 @@ export const ScenarioPage = ({
           "type": "OOB",
           "title": "",
           "text": "",
-          "requestedCredentials": [
-            {
-              "icon": "",
-              "attributes": {
-                  "all":{
-                     "names":[],
-                     "restrictions": []
-                  }
-              },
-              "predicates": {
-              }
-            }
-          ]
+          "proofRequest": {
+            "attributes": {
+            },
+            "predicates": {
+            },
+          },
         }});
       });
       setState("proof-step-edit");

--- a/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
+++ b/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
@@ -54,7 +54,7 @@ function DisplayStepCredentials({
 
 
                 // This line prevents the showcase from crashing, in the event the credential was deleted earlier.
-                // To-do: add code that removes the credential from the scenario JSON when it is deleted from the credetial screen.
+                // Note that this should be handled anyway. On deleting a credential, if that credential was used, the proofRequest is reset to blank/empty.
                 showcaseJSON.personas[selectedCharacter].credentials[credential] ? 
 
 

--- a/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
+++ b/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
@@ -51,8 +51,10 @@ function DisplayStepCredentials({
               localData.requestOptions.proofRequest && localData.requestOptions.proofRequest.attributes ?
               getAllCredentials(localData.requestOptions.proofRequest.attributes, localData.requestOptions.proofRequest.predicates).map(
                 (credential, index) => (
+
+
                 
-                
+                showcaseJSON.personas[selectedCharacter].credentials[credential] ? 
 
 
                 
@@ -116,7 +118,7 @@ function DisplayStepCredentials({
               
               </div>
               
-           
+           : null
                 
                 )) : null
             

--- a/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
+++ b/src/react-modules/scenario-screen/DisplayStepCredentials.jsx
@@ -40,7 +40,7 @@ function DisplayStepCredentials({
     && showcaseJSON.personas[selectedCharacter].onboarding[selectedStep].credentials  
     && showcaseJSON.personas[selectedCharacter].onboarding[selectedStep].credentials.length > 10 ?  (
         <div className="m-5 p-5 w-full h-60">
-          <NoSelection key={"blahblahblah"} Text={"No Credentials Added"} />
+          <NoSelection key={"unique_key"} Text={"No Credentials Added"} />
         </div>
       ) : (
         <div className="m-5">
@@ -53,7 +53,8 @@ function DisplayStepCredentials({
                 (credential, index) => (
 
 
-                
+                // This line prevents the showcase from crashing, in the event the credential was deleted earlier.
+                // To-do: add code that removes the credential from the scenario JSON when it is deleted from the credetial screen.
                 showcaseJSON.personas[selectedCharacter].credentials[credential] ? 
 
 

--- a/src/react-modules/scenario-screen/EditProofRequest.jsx
+++ b/src/react-modules/scenario-screen/EditProofRequest.jsx
@@ -97,8 +97,6 @@ const EditProofRequest = (
                 restrictions: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].name],
         }
         })
-        console.log("HERE")
-        console.log(localData)
     }
 
     const RemoveAttribute = (e, type, index) => {

--- a/src/react-modules/scenario-screen/EditProofRequest.jsx
+++ b/src/react-modules/scenario-screen/EditProofRequest.jsx
@@ -88,8 +88,17 @@ const EditProofRequest = (
     const AddAttribute = (e) =>{
         e.preventDefault()
         setLocalData(json => {
-            json.attributes[showcaseJSON.credentialName].attributes.push(showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name)
+          
+            // json.attributes[showcaseJSON.credentialName].attributes.push(
+            //   showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name
+            //   )
+            json.attributes[showcaseJSON.credentialName] = {
+                attributes: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name],
+                restrictions: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].name],
+        }
         })
+        console.log("HERE")
+        console.log(localData)
     }
 
     const RemoveAttribute = (e, type, index) => {

--- a/src/react-modules/scenario-screen/EditProofRequest.jsx
+++ b/src/react-modules/scenario-screen/EditProofRequest.jsx
@@ -88,14 +88,17 @@ const EditProofRequest = (
     const AddAttribute = (e) =>{
         e.preventDefault()
         setLocalData(json => {
-          
-            // json.attributes[showcaseJSON.credentialName].attributes.push(
-            //   showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name
-            //   )
-            json.attributes[showcaseJSON.credentialName] = {
-                attributes: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name],
-                restrictions: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].name],
-        }
+          if(json.attributes[showcaseJSON.credentialName]){  // If the credential is not blank/empty
+            json.attributes[showcaseJSON.credentialName].attributes.push(
+              showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name
+              )
+          }else{
+            json.attributes[showcaseJSON.credentialName] = { // if the credential IS blank/empty (adding the first attribute to this proof)
+              attributes: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].attributes[0].name],
+              restrictions: [showcaseJSON.showcaseJSON.personas[showcaseJSON.selectedCharacter].credentials[showcaseJSON.credentialName].name],
+      }
+          }
+
         })
     }
 

--- a/src/react-modules/scenario-screen/ProofStepEdit.jsx
+++ b/src/react-modules/scenario-screen/ProofStepEdit.jsx
@@ -67,10 +67,12 @@ function ProofStepEdit({
   function addCredential(event, credential) {
     event.preventDefault();
     setSearchResults([]);
-    if(!localData.requestOptions.proofRequest.attributes[credential]){
+    if(localData.requestOptions.proofRequest && !localData.requestOptions.proofRequest.attributes[credential]){
       setLocalData(json =>{
         json.requestOptions.proofRequest.attributes[credential] = [showcaseJSON.personas[selectedCharacter].credentials[credential].attributes[0].name]
       })
+    }else{
+      console.log(localData.requestOptions)
     }
     
   }


### PR DESCRIPTION
- prevented a crash, when credentials are deleted that are still being referenced from the scenario screen
- reduced the possibility of the above issue by adding code that removes references to a credential, when deleting the credential
- fixed a bug where adding a credential and credential attribute to a new proof request would crash the showcase